### PR TITLE
Add basic Flask app for sensor management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # ProjetAPP
+
+This project contains a simple Flask web application to manage sensors and actuators. It includes user registration, login, and a dashboard to add sensors and update their values.
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
+python app.py
+```
+
+The app will start in debug mode on `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,101 @@
+from flask import Flask, render_template, request, redirect, url_for, flash, session
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change_this_secret'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///site.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db = SQLAlchemy(app)
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(150), unique=True, nullable=False)
+    password_hash = db.Column(db.String(150), nullable=False)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+class Sensor(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(150), nullable=False)
+    value = db.Column(db.String(150))
+
+def create_db():
+    if not os.path.exists('site.db'):
+        with app.app_context():
+            db.create_all()
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            flash('Username already exists')
+        else:
+            user = User(username=username)
+            user.set_password(password)
+            db.session.add(user)
+            db.session.commit()
+            flash('Account created')
+            return redirect(url_for('login'))
+    return render_template('register.html')
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            session['user_id'] = user.id
+            return redirect(url_for('dashboard'))
+        else:
+            flash('Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/dashboard')
+def dashboard():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    sensors = Sensor.query.all()
+    return render_template('dashboard.html', sensors=sensors)
+
+@app.route('/sensor/add', methods=['POST'])
+def add_sensor():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    name = request.form['name']
+    sensor = Sensor(name=name)
+    db.session.add(sensor)
+    db.session.commit()
+    return redirect(url_for('dashboard'))
+
+@app.route('/sensor/<int:sensor_id>/update', methods=['POST'])
+def update_sensor(sensor_id):
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    value = request.form['value']
+    sensor = Sensor.query.get_or_404(sensor_id)
+    sensor.value = value
+    db.session.commit()
+    return redirect(url_for('dashboard'))
+
+@app.route('/logout')
+def logout():
+    session.pop('user_id', None)
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    create_db()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+Werkzeug

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title or 'Sensor Manager' }}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Home</a>
+    <ul class="navbar-nav me-auto">
+      {% if session.get('user_id') %}
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+      {% else %}
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Login</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Register</a></li>
+      {% endif %}
+    </ul>
+  </div>
+</nav>
+<div class="container mt-4">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for msg in messages %}
+        <div class="alert alert-info">{{ msg }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Dashboard</h2>
+<form method="post" action="{{ url_for('add_sensor') }}" class="mb-3">
+  <div class="input-group">
+    <input class="form-control" type="text" name="name" placeholder="Sensor name" required>
+    <button class="btn btn-success" type="submit">Add Sensor</button>
+  </div>
+</form>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Value</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for s in sensors %}
+    <tr>
+      <td>{{ s.name }}</td>
+      <td>{{ s.value or '-' }}</td>
+      <td>
+        <form method="post" action="{{ url_for('update_sensor', sensor_id=s.id) }}" class="d-flex">
+          <input class="form-control me-2" type="text" name="value" placeholder="New value">
+          <button class="btn btn-primary" type="submit">Update</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Welcome to Sensor Manager</h1>
+<p>Manage your sensors and actuators easily.</p>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Login</button>
+</form>
+{% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input class="form-control" type="text" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input class="form-control" type="password" name="password" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Register</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- set up a Flask application with SQLAlchemy models
- implement registration, login, and dashboard
- add HTML templates
- document setup instructions in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6849728371e0832ea62d04aff0274ad1